### PR TITLE
 Makes remote prefix configurable for collector indices

### DIFF
--- a/x-pack/plugins/asset_manager/server/constants.ts
+++ b/x-pack/plugins/asset_manager/server/constants.ts
@@ -9,7 +9,11 @@ export const ASSETS_INDEX_PREFIX = 'assets';
 export const ASSET_MANAGER_API_BASE = '/api/asset-manager';
 
 // How do we even know these are the right indices to hit?
-export const LOGS_INDICES = 'remote_cluster:logs-*,remote_cluster:filebeat-*';
-export const APM_INDICES =
-  'remote_cluster:traces-*,remote_cluster:apm*,remote_cluster:metrics-apm*,remote_cluster:logs-apm*';
-export const METRICS_INDICES = 'remote_cluster:metrics-*,remote_cluster:metricbeat-*';
+// export const LOGS_INDICES = 'remote_cluster:logs-*,remote_cluster:filebeat-*';
+// export const APM_INDICES =
+//   'remote_cluster:traces-*,remote_cluster:apm*,remote_cluster:metrics-apm*,remote_cluster:logs-apm*';
+// export const METRICS_INDICES = 'remote_cluster:metrics-*,remote_cluster:metricbeat-*';
+
+export const LOGS_INDICES = 'logs-*,filebeat-*';
+export const APM_INDICES = 'traces-*,apm*,metrics-apm*,logs-apm*';
+export const METRICS_INDICES = 'metrics-*,metricbeat-*';

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/alerts.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/alerts.ts
@@ -9,8 +9,8 @@ import { Asset } from '../../../../common/types_api';
 import { CollectorOptions } from '.';
 import { collectHosts } from './hosts';
 
-export async function collectAlerts({ client, from }: CollectorOptions): Promise<Asset[]> {
-  const hosts = await collectHosts({ client, from });
+export async function collectAlerts({ client, from, indices }: CollectorOptions): Promise<Asset[]> {
+  const hosts = await collectHosts({ client, from, indices });
 
   const alerts = hosts.flatMap((host) => {
     const alertsForHost: Asset[] = [];

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/containers.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/containers.ts
@@ -5,13 +5,12 @@
  * 2.0.
  */
 
-import { APM_INDICES, LOGS_INDICES, METRICS_INDICES } from '../../../constants';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions } from '.';
 
-export async function collectContainers({ client, from }: CollectorOptions) {
+export async function collectContainers({ client, from, indices }: CollectorOptions) {
   const dsl = {
-    index: [APM_INDICES, LOGS_INDICES, METRICS_INDICES],
+    index: [indices.traces, indices.metrics, indices.logs],
     size: 1000,
     collapse: {
       field: 'container.id',

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/hosts.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/hosts.ts
@@ -5,13 +5,12 @@
  * 2.0.
  */
 
-import { APM_INDICES, METRICS_INDICES, LOGS_INDICES } from '../../../constants';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions } from '.';
 
-export async function collectHosts({ client, from }: CollectorOptions): Promise<Asset[]> {
+export async function collectHosts({ client, from, indices }: CollectorOptions): Promise<Asset[]> {
   const dsl = {
-    index: [APM_INDICES, LOGS_INDICES, METRICS_INDICES],
+    index: [indices.traces, indices.metrics, indices.logs],
     size: 1000,
     collapse: { field: 'host.hostname' },
     sort: [{ _score: 'desc' }, { '@timestamp': 'desc' }],

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/index.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/index.ts
@@ -10,6 +10,11 @@ import { Asset } from '../../../../common/types_api';
 export interface CollectorOptions {
   client: ElasticsearchClient;
   from: number;
+  indices: {
+    metrics: string;
+    logs: string;
+    traces: string;
+  };
 }
 
 export type Collector = (opts: CollectorOptions) => Promise<Asset[]>;

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/pods.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/pods.ts
@@ -5,13 +5,12 @@
  * 2.0.
  */
 
-import { APM_INDICES, LOGS_INDICES, METRICS_INDICES } from '../../../constants';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions } from '.';
 
-export async function collectPods({ client, from }: CollectorOptions) {
+export async function collectPods({ client, from, indices }: CollectorOptions) {
   const dsl = {
-    index: [APM_INDICES, LOGS_INDICES, METRICS_INDICES],
+    index: [indices.traces, indices.metrics, indices.logs],
     size: 1000,
     collapse: {
       field: 'kubernetes.pod.uid',

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/services.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/collectors/services.ts
@@ -5,15 +5,18 @@
  * 2.0.
  */
 
-import { APM_INDICES } from '../../../constants';
 import { Asset } from '../../../../common/types_api';
 import { CollectorOptions } from '.';
 
 const MISSING_KEY = '__unknown__';
 
-export async function collectServices({ client, from }: CollectorOptions): Promise<Asset[]> {
+export async function collectServices({
+  client,
+  from,
+  indices,
+}: CollectorOptions): Promise<Asset[]> {
   const dsl = {
-    index: APM_INDICES,
+    index: indices.traces,
     size: 0,
     sort: [
       {

--- a/x-pack/plugins/asset_manager/server/lib/implicit_collection/index.ts
+++ b/x-pack/plugins/asset_manager/server/lib/implicit_collection/index.ts
@@ -18,6 +18,7 @@ import { CollectorRunner } from './collector_runner';
 export interface ImplicitCollectionOptions {
   inputClient: ElasticsearchClient;
   outputClient: ElasticsearchClient;
+  remotePrefix: string | false;
   intervalMs: number;
   logger: Logger;
 }


### PR DESCRIPTION
## Summary

Hello! I'm not sure if this is the best way to solve this problem, but we need to have a way around hard-coding the remote prefix at the very least. It might be best to eventually try to read in index pattern names from config or something but for now this seems best.

We can merge this in a separate PR from yours if you want but I had to make these changes to get my local copy working so I wanted to preserve what I'd done, at least. 
