### PR TITLE
Fix TS2554: pass KibanaRequest to getForFeature in inference allowlist check

### DIFF
--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/features_identification/index.ts
@@ -105,6 +105,7 @@ export function createStreamsFeaturesIdentificationTask(taskContext: TaskContext
                 logger: taskLogger,
                 featureId: STREAMS_SIG_EVENTS_KI_EXTRACTION_INFERENCE_FEATURE_ID,
                 searchInferenceEndpoints: taskContext.server.searchInferenceEndpoints,
+                request: runContext.fakeRequest,
               });
               taskLogger.debug(`Using connector ${connectorId} for knowledge indicator extraction`);
 

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/insights_discovery.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/insights_discovery.ts
@@ -70,6 +70,7 @@ export function createStreamsInsightsDiscoveryTask(taskContext: TaskContext) {
                 logger: taskLogger,
                 featureId: STREAMS_SIG_EVENTS_DISCOVERY_INFERENCE_FEATURE_ID,
                 searchInferenceEndpoints: taskContext.server.searchInferenceEndpoints,
+                request: runContext.fakeRequest,
               });
               taskLogger.debug(`Using connector ${connectorId} for discovery`);
               const boundInferenceClient = inferenceClient.bindTo({ connectorId });

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/onboarding.ts
@@ -160,6 +160,7 @@ export function createStreamsOnboardingTask(taskContext: TaskContext) {
                     logger: onboardingLogger,
                     featureId: STREAMS_SIG_EVENTS_KI_QUERY_GENERATION_INFERENCE_FEATURE_ID,
                     searchInferenceEndpoints: taskContext.server.searchInferenceEndpoints,
+                    request: runContext.fakeRequest,
                   });
                   onboardingLogger.debug(
                     `Using connector ${connectorIdForError} for rule generation (error enrichment)`

--- a/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/significant_events_queries_generation.ts
+++ b/x-pack/platform/plugins/shared/streams/server/lib/tasks/task_definitions/significant_events_queries_generation.ts
@@ -72,6 +72,7 @@ export function createStreamsSignificantEventsQueriesGenerationTask(taskContext:
                 logger: taskLogger,
                 featureId: STREAMS_SIG_EVENTS_KI_QUERY_GENERATION_INFERENCE_FEATURE_ID,
                 searchInferenceEndpoints: taskContext.server.searchInferenceEndpoints,
+                request: runContext.fakeRequest,
               });
               taskLogger.debug(`Using connector ${connectorId} for rule generation`);
 

--- a/x-pack/platform/plugins/shared/streams/server/routes/utils/log_if_connector_not_in_allowlist.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/utils/log_if_connector_not_in_allowlist.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Logger } from '@kbn/core/server';
+import type { KibanaRequest, Logger } from '@kbn/core/server';
 import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 
 /** Logs at info if the resolved connector is outside the feature allowlist; usage continues. */
@@ -14,18 +14,23 @@ export async function logIfConnectorNotInAllowlist({
   featureId,
   searchInferenceEndpoints,
   logger,
+  request,
 }: {
   resolvedConnectorId: string;
   featureId: string;
   searchInferenceEndpoints?: SearchInferenceEndpointsPluginStart;
   logger: Logger;
+  request: KibanaRequest;
 }): Promise<string> {
   if (!searchInferenceEndpoints) {
     return resolvedConnectorId;
   }
 
   try {
-    const { endpoints } = await searchInferenceEndpoints.endpoints.getForFeature(featureId);
+    const { endpoints } = await searchInferenceEndpoints.endpoints.getForFeature(
+      featureId,
+      request
+    );
     if (endpoints.length === 0) {
       return resolvedConnectorId;
     }

--- a/x-pack/platform/plugins/shared/streams/server/routes/utils/resolve_connector_id_and_check_allowlist.ts
+++ b/x-pack/platform/plugins/shared/streams/server/routes/utils/resolve_connector_id_and_check_allowlist.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { IUiSettingsClient, Logger } from '@kbn/core/server';
+import type { IUiSettingsClient, KibanaRequest, Logger } from '@kbn/core/server';
 import type { SearchInferenceEndpointsPluginStart } from '@kbn/search-inference-endpoints/server';
 import { logIfConnectorNotInAllowlist } from './log_if_connector_not_in_allowlist';
 import { resolveConnectorId } from './resolve_connector_id';
@@ -16,12 +16,14 @@ export async function resolveConnectorIdAndCheckAllowlist({
   logger,
   featureId,
   searchInferenceEndpoints,
+  request,
 }: {
   connectorId?: string;
   uiSettingsClient: IUiSettingsClient;
   logger: Logger;
   featureId: string;
   searchInferenceEndpoints?: SearchInferenceEndpointsPluginStart;
+  request: KibanaRequest;
 }): Promise<string> {
   const resolved = await resolveConnectorId({ connectorId, uiSettingsClient, logger });
   return logIfConnectorNotInAllowlist({
@@ -29,5 +31,6 @@ export async function resolveConnectorIdAndCheckAllowlist({
     featureId,
     searchInferenceEndpoints,
     logger,
+    request,
   });
 }


### PR DESCRIPTION
## Summary

Fixes the TypeScript build failure in [#259375](https://github.com/elastic/kibana/pull/259375) caused by calling `getForFeature(featureId)` with only 1 argument when the `SearchInferenceEndpointsPluginStart` API requires 2: `(featureId: string, request: KibanaRequest)`.

### Changes
- Added `request: KibanaRequest` parameter to `logIfConnectorNotInAllowlist` and `resolveConnectorIdAndCheckAllowlist`
- Updated all 4 task definition callers (`features_identification`, `insights_discovery`, `significant_events_queries_generation`, `onboarding`) to pass `runContext.fakeRequest`

### Build failure reference
- Buildkite build: https://buildkite.com/elastic/kibana-pull-request/builds/417153
- Error: `TS2554: Expected 2 arguments, but got 1` at `log_if_connector_not_in_allowlist.ts:28`

## Test plan
- [x] `yarn test:type_check --project x-pack/platform/plugins/shared/streams/tsconfig.json` passes
- [x] ESLint passes on all changed files

Refs: https://github.com/elastic/kibana/pull/259375